### PR TITLE
Update chainctl script

### DIFF
--- a/k8s/chainctl
+++ b/k8s/chainctl
@@ -34,7 +34,7 @@ if [ -f "chainctl.env" ]; then
   source "chainctl.env"
 fi
 
-config() {
+create_gcloud_config() {
   gcloud config configurations create "$GCLOUD_CONFIG"
   gcloud config set project "$PROJECT_ID"
   gcloud config set compute/zone us-central1-a
@@ -46,7 +46,7 @@ select_gcloud_config() {
     if gcloud config configurations list | grep -q "$GCLOUD_CONFIG"; then
       gcloud config configurations activate "$GCLOUD_CONFIG"
     else
-      config
+      create_gcloud_config
     fi
   fi
 }
@@ -88,7 +88,7 @@ usage() {
   printf "\033[36m%-30s\033[0m %s\n" certificates "Generate self signed certificates."
   printf "\033[36m%-30s\033[0m %s\n" letsencrypt-certificates "Generate letsencrypt certificates."
 
-  printf "\033[36m%-30s\033[0m %s\n" config "Create and activate a GCloud config for this workspace."
+  printf "\033[36m%-30s\033[0m %s\n" debug-config "DEBUG: Create and activate a GCloud config for this workspace."
 }
 
 replace-configmaps() {
@@ -317,8 +317,8 @@ case "$1" in
     certbot -c certbot.ini -d $DOMAIN --manual --preferred-challenges dns certonly
     ;;
 
-  config)
-    config
+  debug-config)
+    create_gcloud_config
     ;;
 
   "")

--- a/k8s/chainctl
+++ b/k8s/chainctl
@@ -34,7 +34,7 @@ if [ -f "chainctl.env" ]; then
   source "chainctl.env"
 fi
 
-create_gcloud_config() {
+config() {
   gcloud config configurations create "$GCLOUD_CONFIG"
   gcloud config set project "$PROJECT_ID"
   gcloud config set compute/zone us-central1-a
@@ -46,7 +46,7 @@ select_gcloud_config() {
     if gcloud config configurations list | grep -q "$GCLOUD_CONFIG"; then
       gcloud config configurations activate "$GCLOUD_CONFIG"
     else
-      create_gcloud_config
+      config
     fi
   fi
 }
@@ -88,7 +88,7 @@ usage() {
   printf "\033[36m%-30s\033[0m %s\n" certificates "Generate self signed certificates."
   printf "\033[36m%-30s\033[0m %s\n" letsencrypt-certificates "Generate letsencrypt certificates."
 
-  printf "\033[36m%-30s\033[0m %s\n" create_gcloud_config "Create and activate a GCloud config for this workspace."
+  printf "\033[36m%-30s\033[0m %s\n" config "Create and activate a GCloud config for this workspace."
 }
 
 replace-configmaps() {
@@ -156,7 +156,7 @@ replace-secrets() {
         ;;
 
       *)
-        kubectl create secret generic $name --from-file=$file --dry-run=true -o yaml | kubectl apply -f -
+        kubectl create secret generic $name --from-file=$type=$file --dry-run=true -o yaml | kubectl apply -f -
         ;;
     esac
   done
@@ -180,7 +180,7 @@ files_with_same_basename() {
   local file=$(basename "$1")
   local type="${file##*.}"
   local basename="$(basename "$file" "$type")"
-  find . -maxdepth 1 -iname "$basename*" -not -name $file
+  find . -maxdepth 1 -iname "$basename*" -not -name $file -not -name "cl-sslcert*"
 }
 
 ambiguous_file_guard() {
@@ -299,16 +299,16 @@ case "$1" in
       printf "Error: you must define DOMAIN in your chainctl.env.\n\n"
       exit 1
     fi
-    openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout sslcert.key \
-      -out sslcert.crt -subj "/OU=chainlink.development/CN=$DOMAIN/O=$DOMAIN"
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout cl-sslcert.secret.key \
+      -out cl-sslcert.secret.crt -subj "/OU=chainlink.development/CN=$DOMAIN/O=$DOMAIN"
     ;;
 
   letsencrypt-certificates)
     certbot -c certbot.ini -d $DOMAIN --manual --preferred-challenges dns certonly
     ;;
 
-  create_gcloud_config)
-    create_gcloud_config
+  config)
+    config
     ;;
 
   "")

--- a/k8s/chainctl
+++ b/k8s/chainctl
@@ -180,7 +180,17 @@ files_with_same_basename() {
   local file=$(basename "$1")
   local type="${file##*.}"
   local basename="$(basename "$file" "$type")"
-  find . -maxdepth 1 -iname "$basename*" -not -name $file -not -name "cl-sslcert*"
+  case "$type" in
+      crt)
+        files=$files | grep -v key
+        ;;
+      key)
+        files=$files | grep -v crt
+        ;;
+      *)
+        find . -maxdepth 1 -iname "$basename*" -not -name $file
+        ;;
+  esac
 }
 
 ambiguous_file_guard() {


### PR DESCRIPTION
- Rename `create_gcloud_config` to `config`.
- Rename output from `chainctl certificates` to match naming convention.
- Exclude cl-sslcert from `ambiguous_file_guard` (`replace-secrets` requires the *.secret.crt and *.secret.key to have the same name). This could use a more elegant method but it works.
- Name secrets for `password` and `api` on disk (this was breaking our run command).