### PR TITLE
Colocate nginx ssl proxy next to ethereum node for https

### DIFF
--- a/k8s/chainctl
+++ b/k8s/chainctl
@@ -85,7 +85,8 @@ usage() {
   printf "\033[36m%-30s\033[0m %s\n" bootstrap-cluster "Create the whole cluster from scratch."
   printf "\033[36m%-30s\033[0m %s\n" proxy "Open a browser to the k8s proxy console."
 
-  printf "\033[36m%-30s\033[0m %s\n" certificates "Generate self signed certificates."
+  printf "\033[36m%-30s\033[0m %s\n" certificates "Generate self signed certificates with naming conventions for chainlink nodes."
+  printf "\033[36m%-30s\033[0m %s\n" ethcertificates "Generate self signed certificates with naming conventions for ethereum nodes."
   printf "\033[36m%-30s\033[0m %s\n" letsencrypt-certificates "Generate letsencrypt certificates."
 
   printf "\033[36m%-30s\033[0m %s\n" ssh "PARAMS: <deployment>. Open a SSH connection to the <deployment>."
@@ -352,6 +353,15 @@ case "$1" in
     fi
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout cl-sslcert.secret.key \
       -out cl-sslcert.secret.crt -subj "/OU=chainlink.development/CN=$DOMAIN/O=$DOMAIN"
+    ;;
+
+  ethcertificates)
+    if [ -z "$DOMAIN" ]; then
+      printf "Error: you must define DOMAIN in your chainctl.env.\n\n"
+      exit 1
+    fi
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ethereum-sslcert.secret.key \
+      -out ethereum-sslcert.secret.crt -subj "/OU=chainlink.development/CN=$DOMAIN/O=$DOMAIN"
     ;;
 
   letsencrypt-certificates)

--- a/k8s/chainctl
+++ b/k8s/chainctl
@@ -112,7 +112,7 @@ replace-configmaps() {
     kubectl delete configmap $name --ignore-not-found=true >/dev/null
     case "$type" in
       yaml)
-        kubectl create configmap $name --from-file=$file
+        kubectl apply -f $file
         ;;
       env)
         kubectl create configmap $name --from-env-file=$file

--- a/k8s/deployments/chainlink-209321/acceptance/chainlink-cfg.configmap.env
+++ b/k8s/deployments/chainlink-209321/acceptance/chainlink-cfg.configmap.env
@@ -1,2 +1,2 @@
 CHAINLINK_TLS_HOST=acceptance-node.chain.link
-ETH_URL=ws://ropsten.geth.chain.link:8546
+ETH_URL=wss://ropsten.geth.chain.link:8546

--- a/k8s/deployments/ethereum-216216/ropsten-geth/chainctl.env
+++ b/k8s/deployments/ethereum-216216/ropsten-geth/chainctl.env
@@ -1,1 +1,2 @@
 TEMPLATES=geth
+DOMAIN=ropsten.geth.chain.link

--- a/k8s/templates/chainlink.yaml
+++ b/k8s/templates/chainlink.yaml
@@ -73,6 +73,9 @@ spec:
             - name: chainlink-crt
               mountPath: /secrets/tls
               readOnly: true
+            - name: ethereum-crt
+              mountPath: /secrets/ethereum
+              readOnly: true
       volumes:
         - name: chainlink-storage
           persistentVolumeClaim:
@@ -86,6 +89,10 @@ spec:
         - name: chainlink-crt
           secret:
             secretName: cl-sslcert
+        - name: ethereum-crt
+          secret:
+            secretName: ethereum-sslcert
+            optional: true
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/k8s/templates/geth.yaml
+++ b/k8s/templates/geth.yaml
@@ -34,9 +34,8 @@ spec:
         app: ethereum
     spec:
       containers:
-        - name: ethereum
-          image: ethereum/client-go:latest
-          args: ["--syncmode", "$(SYNCMODE)", "--$(CHAIN)", "--ws", "--wsport", "8546", "--wsaddr", "0.0.0.0", "--wsorigins", "*", "--rpc", "--rpcport", "8545", "--rpcaddr", "0.0.0.0", "--rpccorsdomain", "*", "--datadir", "/data/ethereum", "--ipcdisable"]
+        - name: nginx
+          image: nginx:latest
           ports:
             - containerPort: 8545
             - containerPort: 8546
@@ -46,6 +45,15 @@ spec:
             - name: discovery
               protocol: UDP
               containerPort: 30303
+          volumeMounts:
+            - name: ethereum-crt
+              mountPath: /secrets/tls
+              readOnly: true
+            - name: nginx-conf-volume
+              mountPath: /etc/nginx/conf.d
+        - name: ethereum
+          image: ethereum/client-go:latest
+          args: ["--syncmode", "$(SYNCMODE)", "--$(CHAIN)", "--port", "60303", "--ws", "--wsport", "18546", "--wsaddr", "0.0.0.0", "--wsorigins", "*", "--rpc", "--rpcport", "18545", "--rpcaddr", "0.0.0.0", "--rpccorsdomain", "*", "--datadir", "/data/ethereum", "--ipcdisable"]
           env:
             - name: CHAIN
               valueFrom:
@@ -64,6 +72,12 @@ spec:
         - name: ethereum-storage
           persistentVolumeClaim:
             claimName: ethereum-pv-claim
+        - name: ethereum-crt
+          secret:
+            secretName: ethereum-sslcert
+        - name: nginx-conf-volume
+          configMap:
+            name: nginx-configmap
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -75,3 +89,46 @@ spec:
   resources:
     requests:
       storage: 128Gi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-configmap
+data:
+  nginx.conf: |
+    server {
+      listen 8545 ssl;
+      ssl_certificate           /secrets/tls/tls.crt;
+      ssl_certificate_key       /secrets/tls/tls.key;
+      location / {
+        proxy_pass  http://localhost:18545;
+      }
+    }
+
+    server {
+      listen 8546 ssl;
+      ssl_certificate           /secrets/tls/tls.crt;
+      ssl_certificate_key       /secrets/tls/tls.key;
+
+      location / {
+        proxy_http_version 1.1;
+
+        proxy_connect_timeout 7d;
+        proxy_send_timeout 7d;
+        proxy_read_timeout 7d;
+
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+
+        proxy_pass  http://localhost:18546;
+      }
+    }
+
+    server {
+      listen 30303 ssl;
+      ssl_certificate           /secrets/tls/tls.crt;
+      ssl_certificate_key       /secrets/tls/tls.key;
+      location / {
+        proxy_pass  http://localhost:60303;
+      }
+    }


### PR DESCRIPTION
Protects the ethereum node with ssl via nginx.

Changes in `chainlink-launcher` adds the ethereum crt to the chainlink node's CA: https://github.com/smartcontractkit/chainlink/pull/653