### PR TITLE
Add container support to chainctl

### DIFF
--- a/k8s/chainctl
+++ b/k8s/chainctl
@@ -241,11 +241,11 @@ patch() {
 }
 
 ssh() {
-  kubectl exec -it `kubectl get pods --no-headers | grep Running | grep "$1" | awk '{print$1}'` -- /bin/bash
+  kubectl exec -it `kubectl get pods --no-headers | grep Running | grep "$1" | awk '{print$1}'` -c "$1" -- /bin/sh
 }
 
 attach() {
-  kubectl attach `kubectl get pods --no-headers | grep Running | grep "$1" | awk '{print$1}'`
+  kubectl attach `kubectl get pods --no-headers | grep Running | grep "$1" | awk '{print$1}'` -c "$1"
 }
 
 backup() {

--- a/k8s/templates/parity.yaml
+++ b/k8s/templates/parity.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
         - name: ethereum
-          image: parity/parity:latest
+          image: parity/parity:stable
           args: ["--chain", "$(CHAIN)", "--ws-port", "8546", "--ws-interface", "all", "--ws-origins", "all", "--jsonrpc-port", "8545", "--jsonrpc-interface", "all", "--jsonrpc-hosts", "all", "--jsonrpc-cors", "all", "--db-path", "/data/ethereum", "--no-ipc"]
           ports:
             - containerPort: 8545


### PR DESCRIPTION
Adds `-c` param so that when we do `chainctl attach ethereum` or `chainctl ssh ethereum` we don't default into the nginx container. Also since ethereum/client-go doesn't come with `bash`, update the ssh command to use `/bin/sh` so that we can be compatible with both images.